### PR TITLE
fix: - restructure navigation

### DIFF
--- a/src/Styles/Nav.js
+++ b/src/Styles/Nav.js
@@ -8,7 +8,6 @@ display:block;
 `;
 export const Container = Style.div`
 flex:2;
-padding-top:30px;
 @media(max-width:450px){
 padding-top:0px;
 }

--- a/src/Styles/login.js
+++ b/src/Styles/login.js
@@ -4,6 +4,10 @@ export const signupContainer = Style.div`
   display:flex;
 
 `;
+export const PTag = Style.p`
+text-align:right;
+padding-right:30px;
+`;
 
 export const SignupLeft = Style.div`
   flex:1;

--- a/src/Styles/signup.js
+++ b/src/Styles/signup.js
@@ -7,8 +7,7 @@ export const signupContainer = Style.div`
 
 export const SignupLeft = Style.div`
   flex:1;
-  background-image: url("https://images.pexels.com/photos/264547/pexels-photo-264547.jpeg?auto=compress&cs=tinysrgb&dpr=1&w=500(28 kB)
-");
+background:url("https://myupdatesystems.com/wp-content/uploads/2018/03/addiction-professional-networking-events-behavioral-health-network-resources.jpg");
   background-size: cover;
    background-position: left 40%;
   background-repeat: no-repeat;
@@ -17,7 +16,8 @@ export const SignupLeft = Style.div`
 `;
 export const Signupright = Style.div`
   flex:1;
-
+text-align:right;
+padding-right:30px;
 `;
 export const FormInput = Style.input`
 background: #fff;

--- a/src/components/login.js
+++ b/src/components/login.js
@@ -15,6 +15,10 @@ export const LoginAuthentication = () => {
 			</SI.SignupLeft>
 
 			<SI.Signupright>
+				<SI.PTag>
+					<Link to="/">Home</Link>
+				</SI.PTag>
+
 				<SI.SignupRightContainer>
 					<SI.Div>Welcome Back!</SI.Div>
 

--- a/src/components/signup.js
+++ b/src/components/signup.js
@@ -19,6 +19,7 @@ export const SignupAuthentication = () => {
 				<SA.SiteLogo></SA.SiteLogo>
 			</SA.SignupLeft>
 			<SA.Signupright>
+				<Link to="/">Home</Link>
 				<SA.SignupHeadText>
 					Already have an account? <Link to="/login">Signin </Link>
 				</SA.SignupHeadText>
@@ -27,50 +28,48 @@ export const SignupAuthentication = () => {
 						<SA.formGroup className="form-group col-md-6">
 							<SA.FormInput
 								type="text"
-								name="username"
-								placeholder="username"
+								name="firstname"
+								placeholder="first Name"
+								className="form-control"
+								onChange={handleChange}
+							/>
+						</SA.formGroup>
+						<SA.formGroup className="form-group col-md-6">
+							<SA.FormInput
+								type="text"
+								name="Lastname"
+								placeholder="Last Name"
+								className="form-control"
+								onChange={handleChange}
+							/>
+						</SA.formGroup>
+						<SA.formGroup className="form-group col-md-6">
+							<SA.FormInput
+								type="text"
+								name="Username"
+								placeholder="Username"
 								className="form-control"
 								onChange={handleChange}
 							/>
 						</SA.formGroup>
 
 						<SA.formGroup className="form-group col-md-6">
-							<SA.FormInput
-								type="number"
-								name="phoneNumber"
-								placeholder="Phone Number"
-								className="form-control"
-							/>
+							<SA.FormInput type="email" name="" placeholder="Email" className="form-control" />
 						</SA.formGroup>
-
-						<SA.formGroup className="form-group col-lg-12">
-							<SA.FormInput
-								type="text"
-								name="userAddress"
-								placeholder="Full Address"
-								className="form-control"
-							/>
-						</SA.formGroup>
-
-						{/* <SA.formGroup className="form-group col-md-6">
-							<SA.FormInput
-								type="text"
-								name="deliveryAddress"
-								placeholder="Full Address"
-								className="form-control"
-	
-							/>
-						</SA.formGroup> */}
-
 						<SA.formGroup className="form-group col-md-6">
-							<SA.FormInput type="email" name="email" placeholder="Email" class="form-control" />
+							<SA.FormInput type="password" name="" placeholder="Password" className="form-control" />
 						</SA.formGroup>
-
 						<SA.formGroup className="form-group col-md-6">
-							<SA.FormInput type="password" name="password" placeholder="Password" class="form-control" />
+							<SA.FormInput type="text" name="" placeholder="Country" className="form-control" />
 						</SA.formGroup>
+						<SA.formGroup className="form-group col-md-6">
+							<SA.FormInput type="text" name="" placeholder="state" className="form-control" />
+						</SA.formGroup>
+						<SA.formGroup className="form-group col-md-6">
+							<SA.FormInput type="date" name="" placeholder="Date of birth" className="form-control" />
+						</SA.formGroup>
+						<SA.SignupBotton type="button">sign Up</SA.SignupBotton>
 					</SA.formRow>
-					<SA.SignupBotton type="button"></SA.SignupBotton>
 				</SA.Form>
 			</SA.Signupright>
 		</SA.signupContainer>


### PR DESCRIPTION
#### What does this PR do?
Refacture signup and login page
#### Description of Task to be completed?
 - restructure signup page with its images
- add home link to signup and login component
#### How should this be manually tested?
- visit https://github.com/olorunwalawrence/borrowIt.git
- clone the repo [https://github.com/olorunwalawrence/borrowIt.git]
- run Yarn install to install dependencies
- run yarn start
-visit  http://localhost:3000/signup on your local machine
visit http://localhost:3000/login to view the login page
![login](https://user-images.githubusercontent.com/44552263/71766673-39182d00-2eb7-11ea-8a7a-4459ae84cada.PNG)
![signup](https://user-images.githubusercontent.com/44552263/71766677-43d2c200-2eb7-11ea-8b40-c861aaccfcda.PNG)


